### PR TITLE
Switched from winapi to windows-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,9 @@ license = "MIT"
 [target.'cfg(not(windows))'.dependencies]
 libc = "0.2.72"
 
-[target.'cfg(windows)'.dependencies]
-kernel32-sys = "0.2.2"
+[target.'cfg(windows)'.dependencies.windows]
+version = "0.39.0"
+features = ["Win32_System_SystemInformation"]
 
 [[bin]]
 name = "uptime-rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
-#[cfg(windows)]
-extern crate kernel32;
 #[cfg(not(windows))]
 extern crate libc;
+#[cfg(windows)]
+extern crate windows;
 
 #[cfg(not(windows))]
 use std::mem;
@@ -51,6 +51,6 @@ pub fn get() -> Result<Duration, String> {
 
 #[cfg(target_os = "windows")]
 pub fn get() -> Result<Duration, String> {
-    let ret: u64 = unsafe { kernel32::GetTickCount64() };
+    let ret: u64 = unsafe { windows::Win32::System::SystemInformation::GetTickCount64() };
     Ok(Duration::from_millis(ret))
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -2,5 +2,5 @@ extern crate uptime_lib;
 
 #[test]
 fn test_uptime_get() {
-    assert_eq!(uptime_lib::get().is_ok(), true);
+    assert!(uptime_lib::get().is_ok());
 }


### PR DESCRIPTION
Thank you for this crate!

While using it with the latest rust, rust gives me this message:
```
warning: the following packages contain code that will be rejected by a future version of Rust: winapi v0.2.8
```

It looks like this could be fixed by updating winapi to the latest version. However I've noticed that the rust ecosystem has been moving from winapi to [windows-rs](https://github.com/microsoft/windows-rs). The change seemed pretty simple.

If instead you want me to bump winapi to the latest version then I can do that as well.

<details>
<summary>Long warning</summary>

```
The package `winapi v0.2.8` currently triggers the following future incompatibility lints:
> warning: `#[derive]` can't be used on a `#[repr(packed)]` struct that does not derive Copy (error E0133)
>    --> C:\Users\micro\scoop\persist\rustup\.cargo\registry\src\github.com-1ecc6299db9ec823\winapi-0.2.8\src\macros.rs:263:29
>     |
> 263 |           #[repr(C)] #[derive(Debug)] $(#[$attrs])*
>     |                               ^^^^^
>     |
>    ::: C:\Users\micro\scoop\persist\rustup\.cargo\registry\src\github.com-1ecc6299db9ec823\winapi-0.2.8\src\mmreg.rs:290:1
>     |
> 290 | / STRUCT!{#[repr(packed)] struct WAVEFORMATEX {
> 291 | |     wFormatTag: ::WORD,
> 292 | |     nChannels: ::WORD,
> 293 | |     nSamplesPerSec: ::DWORD,
> ...   |
> 297 | |     cbSize: ::WORD,
> 298 | | }}
>     | |__- in this macro invocation
>     |
>     = note: `#[allow(unaligned_references)]` on by default
>     = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
>     = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
>     = note: this warning originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
> 
> warning: `#[derive]` can't be used on a `#[repr(packed)]` struct that does not derive Copy (error E0133)
>    --> C:\Users\micro\scoop\persist\rustup\.cargo\registry\src\github.com-1ecc6299db9ec823\winapi-0.2.8\src\macros.rs:263:29
>     |
> 263 |           #[repr(C)] #[derive(Debug)] $(#[$attrs])*
>     |                               ^^^^^
>     |
>    ::: C:\Users\micro\scoop\persist\rustup\.cargo\registry\src\github.com-1ecc6299db9ec823\winapi-0.2.8\src\mmreg.rs:299:1
>     |
> 299 | / STRUCT!{#[repr(packed)] struct WAVEFORMATEXTENSIBLE {
> 300 | |     Format: ::WAVEFORMATEX,
> 301 | |     Samples: ::WORD,
> 302 | |     dwChannelMask: ::DWORD,
> 303 | |     SubFormat: ::GUID,
> 304 | | }}
>     | |__- in this macro invocation
>     |
>     = note: `#[allow(unaligned_references)]` on by default
>     = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
>     = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
>     = note: this warning originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
> 
> warning: `#[derive]` can't be used on a `#[repr(packed)]` struct that does not derive Copy (error E0133)
>    --> C:\Users\micro\scoop\persist\rustup\.cargo\registry\src\github.com-1ecc6299db9ec823\winapi-0.2.8\src\macros.rs:263:29
>     |
> 263 |           #[repr(C)] #[derive(Debug)] $(#[$attrs])*
>     |                               ^^^^^
>     |
>    ::: C:\Users\micro\scoop\persist\rustup\.cargo\registry\src\github.com-1ecc6299db9ec823\winapi-0.2.8\src\usbspec.rs:26:1
>     |
> 26  | / STRUCT!{#[repr(packed)] struct USB_CONFIGURATION_DESCRIPTOR {
> 27  | |     bLength: ::UCHAR,
> 28  | |     bDescriptorType: ::UCHAR,
> 29  | |     wTotalLength: ::USHORT,
> ...   |
> 34  | |     MaxPower: ::UCHAR,
> 35  | | }}
>     | |__- in this macro invocation
>     |
>     = note: `#[allow(unaligned_references)]` on by default
>     = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
>     = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
>     = note: this warning originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
> 
> warning: `#[derive]` can't be used on a `#[repr(packed)]` struct that does not derive Copy (error E0133)
>    --> C:\Users\micro\scoop\persist\rustup\.cargo\registry\src\github.com-1ecc6299db9ec823\winapi-0.2.8\src\macros.rs:263:29
>     |
> 263 |           #[repr(C)] #[derive(Debug)] $(#[$attrs])*
>     |                               ^^^^^
>     |
>    ::: C:\Users\micro\scoop\persist\rustup\.cargo\registry\src\github.com-1ecc6299db9ec823\winapi-0.2.8\src\winusb.rs:8:1
>     |
> 8   | / STRUCT!{#[repr(packed)] struct WINUSB_SETUP_PACKET {
> 9   | |     RequestType: ::UCHAR,
> 10  | |     Request: ::UCHAR,
> 11  | |     Value: ::USHORT,
> 12  | |     Index: ::USHORT,
> 13  | |     Length: ::USHORT,
> 14  | | }}
>     | |__- in this macro invocation
>     |
>     = note: `#[allow(unaligned_references)]` on by default
>     = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
>     = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
>     = note: this warning originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
> 
```

</details>