### PR TITLE
Add error type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ repository = "https://github.com/itchyny/uptime-rs"
 readme = "README.md"
 license = "MIT"
 
+[dependencies]
+thiserror = "1"
+
 [target.'cfg(not(windows))'.dependencies]
 libc = "0.2.126"
 


### PR DESCRIPTION
This patch adds an `Error` type, so that downstream users can more easily consume the API of this crate.

---

Hi!
I found this crate useful and figured that this might improve the code a bit for downstream users - mainly because stringly-typed APIs are not really a nice thing.