### PR TITLE
chore(clippy): fix clippy warning on Windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,8 @@ pub fn get() -> Result<Duration, Error> {
 }
 
 #[cfg(target_os = "windows")]
+// `Result` is needed to match the signature on other platforms
+#[allow(clippy::unnecessary_wraps)]
 pub fn get() -> Result<Duration, Error> {
     let ret: u64 = unsafe { windows::Win32::System::SystemInformation::GetTickCount64() };
     Ok(Duration::from_millis(ret))


### PR DESCRIPTION
I noticed this while working on the same thing Thomas Eizinger is working on.

Also I was thinking of vendoring this to handle the problem of `windows` being 0.x and breaking with every release. We have like 7 versions of `windows` in our dependency tree atm 😭 

This is where I'd be vendoring it, I think our licenses are compatible and you're still credited and all. https://github.com/firezone/firezone/pull/5625/files